### PR TITLE
Add installation and packaging targets [chenla]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,97 @@
+# Created by https://www.toptal.com/developers/gitignore/api/macos,windows,linux,cmake
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,windows,linux,cmake
+
+### CMake ###
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+### CMake Patch ###
+# External projects
+*-prefix/
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,windows,linux,cmake
+
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,29 @@ find_package(yaml-cpp 0.6 REQUIRED)
 add_library(cpackexamplelib filesystem/filesystem.cpp fem/fem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
 add_executable("${PROJECT_NAME}" main.cpp)
 
+set_target_properties(cpackexamplelib PROPERTIES PUBLIC_HEADER "filesystem/filesystem.hpp;fem/fem.hpp;flatset/flatset.hpp;yamlParser/yamlParser.hpp")
+target_include_directories(cpackexamplelib
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib>
+)
+
 target_link_libraries("${PROJECT_NAME}" cpackexamplelib)
 target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+include(GNUInstallDirs)
+install(TARGETS "${PROJECT_NAME}" cpackexamplelib
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib
+  )
+
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+include(CPackConfig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,11 @@ target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
 
+install(FILES ${CMAKE_SOURCE_DIR}/copyright
+  DESTINATION "/usr/share/doc/${PROJECT_NAME}/"
+  COMPONENT Documentation
+)
+
 include(GNUInstallDirs)
 install(TARGETS "${PROJECT_NAME}" cpackexamplelib
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,14 @@
+set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
+set(CPACK_PACKAGE_VENDOR "SSE Lecturers")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "SSE CPack Exercise 2024/25W"
+CACHE STRING "This is an exercise to create a package with CPack.")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/lingachen/cpack-exercise-wt2425")
+set(CPACK_PACKAGE_CONTACT "st191429@stud.uni-stuttgart.de")
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+# set(CPACK_DEBIAN_PACKAGE_DEPENDS "libyaml-cpp")
+set(CPACK_STRIP_FILES TRUE)
+
+set(CPACK_GENERATOR "TGZ;DEB")
+
+include(CPack)

--- a/copyright
+++ b/copyright
@@ -1,0 +1,26 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: cpack-exercise-wt2425
+Source: https://github.com/lingachen/cpack-exercise-wt2425
+
+Files: *
+Copyright: 2024 LingChia Chen <st191429@stud.uni-stuttgart.de>
+License: MIT
+
+License: MIT
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.


### PR DESCRIPTION
To build and test the packages, follow the commands to build a Docker image and build:

```bash
git clone https://github.com/lingachen/cpack-exercise-wt2425.git
cd cpack-exercise-wt2425.git
docker build -t IMAGENAME .
docker run --rm -it --mount type=bind,source="$(pwd)",target=/mnt/cpack-exercise IMAGENAME

mkdir build && cd build
cmake ..
make package
make install
```
Here is the output of `lintian`:
<img width="982" alt="截圖 2024-12-04 下午5 12 08" src="https://github.com/user-attachments/assets/67089c74-65ec-4c0e-8c04-418649f93ff5">


I add `set(CPACK_STRIP_FILES TRUE)` into `cmake/CPackConfig.cmake` to strip the output file. 

Here is the output after stripping:
<img width="982" alt="截圖 2024-12-04 下午5 15 02" src="https://github.com/user-attachments/assets/eefa72b6-ae28-42fb-8235-2d9ee51d959c">

Furthermore, I add a copyright file and add an install target in `CMakeLists.txt` to resolve the lintian error: `no-copyright-file`
<img width="869" alt="截圖 2024-12-08 晚上11 52 22" src="https://github.com/user-attachments/assets/f28f0dc1-5007-4a11-ac2d-6b19f0e747ab">

