### PR TITLE
Add installation and packaging targets [gilvv]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,16 +7,46 @@ FIND_PACKAGE(deal.II 9.5 REQUIRED
   )
 DEAL_II_INITIALIZE_CACHED_VARIABLES()
 
+add_library(cpackexamplelib filesystem/filesystem.cpp fem/fem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
+
+target_sources(cpackexamplelib
+   PUBLIC FILE_SET HEADERS
+   BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} FILES
+     ${CMAKE_CURRENT_SOURCE_DIR}/fem/fem.hpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/filesystem/filesystem.hpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/flatset/flatset.hpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/yamlParser/yamlParser.hpp
+ )
+
 # Uses the FindBoost module of CMake
 find_package(Boost 1.83 COMPONENTS filesystem REQUIRED)
 
 find_package(yaml-cpp 0.6 REQUIRED)
 
-add_library(cpackexamplelib filesystem/filesystem.cpp fem/fem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
 add_executable("${PROJECT_NAME}" main.cpp)
 
 target_link_libraries("${PROJECT_NAME}" cpackexamplelib)
 target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CPackConfig.cmake)
+
+target_include_directories(cpackexamplelib
+   PUBLIC
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib>
+ )
+
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+include(GNUInstallDirs)
+ install(TARGETS cpackexamplelib cpackexample
+   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+   )
+
+   install(TARGETS cpackexamplelib
+     FILE_SET HEADERS
+     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib
+   )

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 From ubuntu:24.04
 
+WORKDIR /mnt/cpack-exercise
 # Install a few dependencies
 RUN apt-get -qq update && \
     apt-get -qq -y install \
@@ -24,5 +25,15 @@ RUN mkdir software && cd software && \
 ENV LIBRARY_PATH $LIBRARY_PATH:/usr/local/lib/
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:/usr/local/lib/
 ENV PATH $PATH:/usr/local/bin/
+
+COPY . .
+
+#The commands build the code using cmake and make. It then installs and make the debian package 
+RUN mkdir build && cd build \
+    && cmake -DCMAKE_INSTALL_PREFIX:PATH=/mnt/cpack-exercise/cpackexample .. \ 
+    && make -j \
+    && make install \
+    && make package \
+    && apt install ./cpackexample-0.1.0-Linux.deb
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,9 @@ RUN mkdir build && cd build \
     && make package \
     && apt install ./cpackexample-0.1.0-Linux.deb
 
+RUN useradd -ms /bin/bash myuser
+
+# Switch to the new user
+USER myuser
+
 CMD ["/bin/bash"]

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,19 @@
+set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
+set(CPACK_PACKAGE_VENDOR "gilvv")
+set(CPACK_PACKAGE_CONTACT "Vaibhav Gil<st191590@stud.uni-stuttgart.de>")
+
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/Menkalian/cpack-exercise-wt2425")
+set(CPACK_GENERATOR "TGZ;DEB")
+set(CPACK_STRIP_FILES TRUE)
+
+
+
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "C++ code testing cpack and cmake along with packaging for Software simulation Engineering.")
+ string(CONCAT CPACK_PACKAGE_DESCRIPTION
+     "#${PROJECT_NAME}\n"
+    "Sample C++ code.\n"
+    "This project includes multiple dependencies,\n"
+    "and was built using cpack, cmake, and make"
+ )
+
+ include(CPack)


### PR DESCRIPTION
You just need to build the image and run the container:
docker build . -t cpack-exercise 
docker run -it --rm --name test-container cpack-exercise  

You will logged in to the terminal. The apt package is already installed. Everything is available in the build directory.

You can see the tree structure:
cd /mnt/cpack-exercise/cpackexample
tree

I was able to create the cmakeconfig file and also create and install the debian package.
<img width="1242" alt="image" src="https://github.com/user-attachments/assets/aa0b5bd4-da8b-49cb-8e20-bec16b275197">

I added the following line to make sure that stripping was being done while the creation of the package:
set(CPACK_STRIP_FILES TRUE)
<img width="1242" alt="Screenshot 2024-12-10 at 6 59 45 PM" src="https://github.com/user-attachments/assets/3cd69461-def5-4786-ad97-7826f5bab2fe">

When this was set to FALSE the resulting package's size was increased to 4,5MB
<img width="1242" alt="Screenshot 2024-12-10 at 7 01 57 PM" src="https://github.com/user-attachments/assets/894901c8-d1cf-468b-8b85-dc1d204b2a25">

If you are not adding this in the cmakeconfig file, you can also set this at the time of cmake command like so:
cmake -DCMAKE_INSTALL_PREFIX:PATH=/mnt/cpack-exercise/cpackexample -D CPACK_STRIP_FILES=TRUE ..  

I had also tried doing the optional task which allows the host to have the tar.gz file and .deb package file on the host after the container exists.
I was able to figure out an alternative.

Run the docker container:
docker run -it --rm --name test-container cpack-exercise 

Open another terminal and run the following commands:
docker cp test-container-1:/mnt/cpack-exercise/build/cpackexample-0.1.0-Linux.deb .
docker cp test-container-1:/mnt/cpack-exercise/build/cpackexample-0.1.0-Linux.tar.gz . 

It doesn't really solve the automization problem but that is what I could do.