### PR TITLE
Add installation and packaging targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,3 +20,25 @@ target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+set_target_properties(cpackexamplelib PROPERTIES PUBLIC_HEADER "fem/fem.hpp;filesystem/filesystem.hpp;flatset/flatset.hpp;yamlParser/yamlParser.hpp")
+
+target_include_directories(cpackexamplelib
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib>
+)
+
+include(GNUInstallDirs)
+install(TARGETS "${PROJECT_NAME}" cpackexamplelib
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/include/cpackexamplelib
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/
+  )
+
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(CPackConfig)

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,31 @@
+# Set the package's version
+set(CPACK_PACKAGE_VERSION_MAJOR "0")
+set(CPACK_PACKAGE_VERSION_MINOR "1")
+set(CPACK_PACKAGE_VERSION_PATCH "0")
+
+# Set the package's metadata
+set(CPACK_PACKAGE_NAME "cpackexample")
+set(CPACK_PACKAGE_VENDOR "Saranya Vanga")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "An example CPack packaging setup")
+set(CPACK_PACKAGE_DESCRIPTION "This package provides an example of using CPack with a CMake-based project.")
+set(CPACK_PACKAGE_MAINTAINER "Saranya Vanga <vangasaranya1289@example.com>")
+set(CPACK_PACKAGE_CONTACT "vangasaranya1289@example.com")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/SaranyaVanga2508/cpack-exercise-wt2425")
+
+# Specify where to install files
+set(CPACK_PACKAGE_INSTALL_DIRECTORY "cpackexample")
+
+# Specify packaging formats
+set(CPACK_GENERATOR "TGZ;DEB")
+set(CPACK_STRIP_FILES TRUE)
+
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Saranya Vanga <vangasaranya1289@example.com>")
+set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")  
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libyaml-cpp0.6")
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/cmake/documents/changelog.gz" DESTINATION ${CMAKE_INSTALL_DOCDIR})
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/cmake/documents/copyright" DESTINATION ${CMAKE_INSTALL_DOCDIR})
+
+include(CPack)

--- a/cmake/documents/changelog.gz
+++ b/cmake/documents/changelog.gz
@@ -1,0 +1,5 @@
+cpackexample (0.1.0) stable; urgency=low
+
+  * Initial release of cpackexample
+
+-- Saranya Vanga <vangasaranya1289@example.com>  Mon, 09 Dec 2024 00:00:00 +0000

--- a/cmake/documents/copyright
+++ b/cmake/documents/copyright
@@ -1,0 +1,7 @@
+Format: http://dep.debian.net/deps/dep5/
+Upstream-Name: cpackexample
+Source: https://github.com/SaranyaVanga2508/cpack-exercise-wt2425
+
+Files: *
+Copyright: 2024 Saranya Vanga <vangasaranya1289@example.com>
+License: MIT


### PR DESCRIPTION
Steps -
1. Fork the [Repository]( https://github.com/Simulation-Software-Engineering/cpack-exercise-wt2425 ) and then clone it.
2. Build the Docker image: `docker build -t cpack-exercise .`
3. Run the Docker image:  `docker run --rm -it --mount type=bind,source="$(pwd)",target=/mnt/cpack-exercise cpack-exercise`
4. Inside the container : 
  `cd /mnt/cpack-exercise/`
  `mkdir build && cd build`
  `cmake ..`
  `make package`
  
  Output before resolving errors:

![WhatsApp Image 2024-12-09 at 22 56 04_563e33d0](https://github.com/user-attachments/assets/a4a4415e-e1ea-40a9-bda9-2aece99f55e3)

  Output after resolving errors:
  
![WhatsApp Image 2024-12-09 at 23 06 31_24b7fe5a](https://github.com/user-attachments/assets/de5efc30-1722-4197-a050-f9f75c4c003a)

