### PR TITLE
Add installation and packaging targets [wanivi]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,19 +4,49 @@ project("cpackexample" VERSION 0.1.0)
 
 FIND_PACKAGE(deal.II 9.5 REQUIRED
   HINTS ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}
-  )
+)
 DEAL_II_INITIALIZE_CACHED_VARIABLES()
+
+set(CMAKE_SKIP_RPATH ON)
+set(CPACK_SOURCE_IGNORE_FILES "/build/;/CMakeFiles/")
 
 # Uses the FindBoost module of CMake
 find_package(Boost 1.83 COMPONENTS filesystem REQUIRED)
 
 find_package(yaml-cpp 0.6 REQUIRED)
 
+# Create the library
 add_library(cpackexamplelib filesystem/filesystem.cpp fem/fem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
+
+# Create the executable
 add_executable("${PROJECT_NAME}" main.cpp)
 
+# Link libraries
 target_link_libraries("${PROJECT_NAME}" cpackexamplelib)
 target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
+# Setup targets for deal.II
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+# Define installation rules
+# Install the executable
+install(TARGETS "${PROJECT_NAME}"
+    RUNTIME DESTINATION bin
+)
+
+# Install the library
+install(TARGETS cpackexamplelib
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+
+# Install the header files
+install(FILES fem/fem.hpp filesystem/filesystem.hpp flatset/flatset.hpp yamlParser/yamlParser.hpp
+    DESTINATION include/cpackexamplelib
+)
+
+install(FILES ${CMAKE_SOURCE_DIR}/copyright
+    DESTINATION /usr/share/doc/cpackexample)
+
+include(cmake/CPackConfig.cmake)

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,26 @@
+include(CPack)
+
+# Set package details
+set(CPACK_PACKAGE_NAME "cpackexample")
+set(CPACK_PACKAGE_VERSION "0.1.0")
+set(CPACK_PACKAGE_DESCRIPTION "Detailed description of the cpackexample package.")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Example project to demonstrate CPack packaging")
+set(CPACK_PACKAGE_VENDOR "Vaish-W")
+set(CPACK_PACKAGE_CONTACT "wanivaishnavi16@gmail.com")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/Vaish-W/cpack-exercise-wt2425")
+
+# Licensing and README
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+
+# Specify generators
+set(CPACK_GENERATOR "TGZ;DEB")
+
+# Debian-specific configuration
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Vaishnavi <wanivaishnavi16@gmail.com>")  # Required field
+set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
+set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libyaml-cpp-dev, libboost-filesystem1.83.0")
+set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}")
+include(CPack)
+

--- a/copyright
+++ b/copyright
@@ -1,0 +1,22 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Source: https://github.com/niyati-n/cpack-exercise-wt2425
+
+Files: *
+Copyright: 2024 Vaishnavi<wanivaishnavi16@gmail.com>
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
1. Install Dependencies: 
```bash
   sudo apt update
   sudo apt install -y cmake build-essential libboost-filesystem-dev libyaml-cpp-dev libopenmpi-dev
```
2. Build the Project:
`mkdir build && cd build
`cmake`
`make`

3. Package the Project:
`make package`

4. Install and run:
`sudo apt install ./cpackexample-0.1.0.deb`
`cpackexample`

Lintian errors resolved:
1. Disabled RPATH in CMakeLists.txt: `set(CMAKE_SKIP_RPATH ON)`
2. Ignored build-related files:
3. Added copyright file
4. Package starting with article A, An removed in .cmake
5. Description in .cmake
6. Maintainers description format: added email

Before fixing errors:
![before fixing](https://github.com/user-attachments/assets/b46e872b-39a7-4ce1-8c27-88aa0afeb7d6)

After fixing errors:
![After fixing](https://github.com/user-attachments/assets/7f38cf8b-3626-405a-afcc-e86467c7b8e3)
