### PR TITLE
Add installation and packaging targets [luosg]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,3 +20,17 @@ target_link_libraries(cpackexamplelib Boost::filesystem ${YAML_CPP_LIBRARIES})
 
 DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
 DEAL_II_SETUP_TARGET(cpackexamplelib)
+
+include(GNUInstallDirs)
+
+install(TARGETS cpackexamplelib
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+install(DIRECTORY fem/ filesystem/ flatset/ yamlParser/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpackexamplelib
+        FILES_MATCHING PATTERN "*.hpp")
+
+include(cmake/CPackConfig.cmake)

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -1,0 +1,21 @@
+set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
+set(CPACK_PACKAGE_VENDOR "SSE Student")
+set(CPACK_PACKAGE_CONTACT "schitingluo@gmail.com")
+set(CPACK_PACKAGE_MAINTAINERS "SchitingLuo")
+
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "SSE CPack Exercise")
+set(CPACK_PACKAGE_DESCRIPTION "package the code from the CMake exercise with CPack")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/SchitingLuo/cpack-exercise-wt2425.git")
+
+set(CPACK_GENERATOR "TGZ;DEB")
+
+# set(CPACK_DEBIAN_PACKAGE_DEPENDS "libyaml-cpp0.8, libboost-filesystem-dev, libc6")
+
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER ${CPACK_PACKAGE_MAINTAINERS})
+# set(CPACK_DEBIAN_PACKAGE_DEPENDS "libyaml-cpp")
+set(CPACK_STRIP_FILES TRUE)
+
+
+include(CPack)

--- a/copyright
+++ b/copyright
@@ -1,0 +1,13 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Source: https://github.com/SchitingLuo/cpack-exercise-wt2425.git
+Upstream-Name: cpack-exercise-wt2425
+
+Files:
+ *
+Copyright: 2024 SchitingLuo <schiitngluo@gmail.com>
+License: MIT
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.


### PR DESCRIPTION
1. Fork and clone the repository.
2. Build the Docker image: `docker build -t cpackexercise .`
3.  run the Docker : `docker run --rm -it --mount type=bind,source="$(pwd)",target=/mnt/cpack-exercise cpackexercise`
4. build the code:
`cd /mnt/cpack-exercise/`
`mkdir build && cd build`
`cmake ..`
`make package`
5. check debian package with lintian: 
`lintian ./DEBFILENAME`
6. Following output is obtained:
<img width="533" alt="cpackexercise_1" src="https://github.com/user-attachments/assets/47f0034d-28ab-4afd-bb49-fec6e004c1c3">
